### PR TITLE
[Dev Container] add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf
+*.gif binary
+*.jpeg binary
+*.png binary
+*.gz binary
+*.jar binary


### PR DESCRIPTION
Now that we'll work in a Linux Container it appears that quite some files have been modified, mainly because of the difference between the end of line.

![grafik](https://user-images.githubusercontent.com/25108568/176945267-8e60f0d0-623c-4e5a-86cc-cdc65167d69b.png)

Simply cloned the content of the file from the microsoft/vscode-dev-containers repo