### PR TITLE
Update upload-pages-artifact to v4

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -56,7 +56,7 @@ jobs:
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./public
 


### PR DESCRIPTION
Latest build throws an Error: _This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/_ (See: https://github.com/microsoft/alguidelines/actions/runs/16831704259/job/47680779238)

This PR fixes the build error.