### PR TITLE
update deploy-pages version to v4

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -70,4 +70,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Try to fix latest workflow deploy step error:

```
Run actions/deploy-pages@v2
Artifact exchange URL: https://pipelinesghubeus26.actions.githubusercontent.com/yht3pkwUNoUqn7DRI6zPRvQ8AsLWdztYVCSxEkoJeEdZziJnX5/_apis/pipelines/workflows/16872693935/artifacts?api-version=6.0-preview
Error: Getting signed artifact URL failed
Error: HttpError: Cannot find any run with github.run_id 16872693935.
    at processRuntimeResponse (/home/runner/work/_actions/actions/deploy-pages/v2/src/internal/api-client.js:48:1)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at getSignedArtifactMetadata (/home/runner/work/_actions/actions/deploy-pages/v2/src/internal/api-client.js:82:1)
    at Deployment.create (/home/runner/work/_actions/actions/deploy-pages/v2/src/internal/deployment.js:68:1)
    at main (/home/runner/work/_actions/actions/deploy-pages/v2/src/index.js:30:1)
Error: Error: Failed to create deployment (status: 404) with build version aa63b549fb5b72c0c0c5d3218ff52199847dba32. Ensure GitHub Pages has been enabled: https://github.com/microsoft/alguidelines/settings/pages
```