### PR TITLE
`SetLoadFields` and `SetRange` can be swapped

### DIFF
--- a/content/docs/agentic-coding/vibe-coding-rules/al-performance.md
+++ b/content/docs/agentic-coding/vibe-coding-rules/al-performance.md
@@ -74,10 +74,10 @@ Item.FindFirst();
 ```
 
 ```al
-// Bad example (avoid SetLoadFields after filtering)
-Item.SetLoadFields("Item Category Code");
+// Bad example - SetLoadFields should be called before database operations like `FindFirst` or `FindSet`
 Item.SetRange("Third Party Item Exists", false);
 Item.FindFirst();
+Item.SetLoadFields("Item Category Code");
 ```
 
 ## Rule 3: Use Temporary Tables, Dictionaries, and Lists for Performance


### PR DESCRIPTION
In the [official documentation](https://learn.microsoft.com/en-us/dynamics365/business-central/dev-itpro/developer/methods-auto/record/record-setloadfields-method) on `SetLoadFields` method nothing suggest that order of `SetFilter`/`SetRange` and `SetLoadFields` matters.